### PR TITLE
fix capistrano version

### DIFF
--- a/capistrano-smartlogging.gemspec
+++ b/capistrano-smartlogging.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "capistrano", [">= 3.1.0", "< 4.0.0"]
   spec.add_runtime_dependency "sshkit", [">= 1.6.1", "!= 1.7.0"]
 
   spec.add_development_dependency "bundler"#, "~> 1.8"


### PR DESCRIPTION
Put a capistrano version of restrictions that can be used
3.x.x
(>=3.0.0 and < 4.0.0)
